### PR TITLE
circle-ci: apt-get update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: circleci/python:2.7.15-stretch
     steps:
       - checkout
+      - run: apt-get update
       - run:
           name: Install locales
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/python:2.7.15-stretch
     steps:
       - checkout
-      - run: apt-get update
+      - run: sudo apt-get update
       - run:
           name: Install locales
           command: |


### PR DESCRIPTION
It can happen that it fetches old versions that are no longer available, thus breaking the CI